### PR TITLE
Fix: Dev server not loading favicon issue

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -9,9 +9,7 @@ const devConfig = {
   },
 
   devServer: {
-    static: {
-      directory: paths.build(),
-    },
+    static: false,
   },
 };
 


### PR DESCRIPTION
Because `devServer.static` was `true`,
Static files were served from the `src` directory.
The image in a different directory wasn't served.
