### PR TITLE
Fix: Images not loading on recompilation w/ webpack-dev-server

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -11,6 +11,9 @@ const devConfig = {
   devServer: {
     static: false,
   },
+  output: {
+    clean: false,
+  },
 };
 
 const config = merge(commonConfig, devConfig);


### PR DESCRIPTION
This issue is not yet solved; See:
https://github.com/jantimon/html-webpack-plugin/issues/1709

This setting is a workaround,
but it doesn't have any effect
because `webpack-dev-server` loads files in memory anyway.
